### PR TITLE
Add OSE support

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "torchlight",
 	"title": "TorchLight",
 	"description": "TorchLight HUD Controls",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"author": "PhilippeK",
 	"languages": [
 		{
@@ -25,5 +25,5 @@
 	"manifest": "https://raw.githubusercontent.com/PhilippeKr/TorchLight/main/module.json",
 	"download": "https://github.com/PhilippeKr/TorchLight/raw/main/torchlight.zip",
 	"minimumCoreVersion": "0.5.4",
-	"compatibleCoreVersion": "0.7.5"
+	"compatibleCoreVersion": "0.7.10"
 }

--- a/torchlight.js
+++ b/torchlight.js
@@ -507,8 +507,6 @@ class TorchLight {
 			let hasItem = false;
 			actor.data.items.forEach(item => {
 				if (item.name.toLowerCase() === itemToCheck.toLowerCase()) {
-					console.log(item.name);
-					console.log(item);
 					if (item.data.quantity > 0 && game.system.id === 'dnd5e')
 						hasItem = true;
 					if (item.data.quantity.value > 0 && game.system.id === 'ose')


### PR DESCRIPTION
This primarily makes two basic changes.

1. Add support for the 'ose' system module. Enabling inventory checks and reductions using ose items, etc. I also allowed for default values for Torches and Oil flasks that match the ose OGL content from that module.
2. Repair some areas where 'Oil (Flask)' and 'Torch' were hard-coded into locations.